### PR TITLE
Sadly Google Image Chart is deprecated 👎 why not use image-charts as a replacement? :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
-GoogleChart helper for easy generating image charts using Google Chart API
+GoogleChart helper for easy generating image charts using ~~Google Chart API~~ [Image-Charts](https://image-charts.com), a drop-in-replacement for the soon-to-be-shutdown Google Image Chart.
 
 Description later... see examples. I developed it for the purposes I needed now (bar and pie charts), so you may find many options missing. I will add them if I will need them in next project so please be patient or fork and contribute. Enjoy.
 
 This plugin is for CakePHP 2.x
 
-Short example: 
+Short example:
 
 Controller:
 
+```php
 public $helpers = array('GoogleChart.GoogleChart');
+```
 
 View:
 
+```php
 // example of bar chart
 echo $this->GoogleChart->create()
 	->setType('bar', array('horizontal', 'grouped'))
@@ -23,7 +26,7 @@ echo $this->GoogleChart->create()
 	->addMarker('value', array('size' => 14, 'color' => '000000'))
 	->addAxis('x', array('labels' => array('jan 2012', 'feb 2012')))
 	->addAxis('y', array('axis_or_tick' => 'l', 'size' => 12));
-	
+
 // example of pie chart
 echo $this->GoogleChart->create()
 	->setTitle('CHART TITLE', array('size' => 14, 'color' => '000000'))
@@ -32,3 +35,4 @@ echo $this->GoogleChart->create()
 	->setMargins(10, 10, 10, 10)
 	->addData(array(20, 35, 50, 10))
 	->setPieChartLabels(array('first', 'second', 'third', 'and so on...'));
+```

--- a/View/Helper/GoogleChartHelper.php
+++ b/View/Helper/GoogleChartHelper.php
@@ -2,14 +2,14 @@
 App::uses('AppHelper', 'Helper');
 
 /**
- * Helper for working with Google chart API
+ * Helper for working with Image-Charts (a drop-in-replacement for the deprecated Google Image Charts)
  */
 
 class GoogleChartHelper extends AppHelper {
 	/**
-	 * Google chart API url
+	 * Image-Charts API url
 	 */
-	const CHART_API_URL = 'http://%d.chart.apis.google.com/chart?';
+	const CHART_API_URL = 'https://image-charts.com/chart?';
 	/**
 	 * Helpers
 	 */


### PR DESCRIPTION
Hello @segy !

Nice little helper! Sadly Google Image Chart is deprecated since 2012 and can be shutdown at anytime since 2015, so we've built Image-Charts as a replacement for it (bonus: with [gif animation support](https://image-charts.com/documentation#chart-gif-animation)!)
